### PR TITLE
Fix cases where error is of type Message.

### DIFF
--- a/src/app/services/stomp/stomp.service.ts
+++ b/src/app/services/stomp/stomp.service.ts
@@ -199,9 +199,13 @@ export class STOMPService {
 
 
   // Handle errors from stomp.js
-  public on_error = (error: string) => {
+  public on_error = (error: string | Stomp.Message) => {
 
-    console.error('Error: ' + error);
+    if (typeof error === 'object') {
+      error = (<Stomp.Message>error).body;
+    }
+
+    console.error(`Error: ${error}`);
 
     // Check for dropped connection and try reconnecting
     if (error.indexOf('Lost connection') !== -1) {


### PR DESCRIPTION
There are cases where the error parameter of the error callback function is of type `Message` instead of `string`. This fix handles those cases.